### PR TITLE
Modified the boilerplate readme to be more contextualized and project specific

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -1,6 +1,6 @@
 What I want to do next:
 
 - Figure out how to run the spotchecking more quickly.
-[fixed] Fix history and see how to see words I have reviewed recently.
-- Adapt with the extension tools I have built under /tools repo 
-- Match sentence with deck entries 
+- [fixed] Fix history and see how to see words I have reviewed recently.
+- [fixed] Adapt with the extension tools I have built under /tools repo 
+- [fixed] Match sentence with deck entries 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Anki MCP Server
 
-A Model Context Protocol server implementation for interacting with Anki decks programmatically. This server allows Language Models to interact with Anki through a standardized interface.
+A Model Context Protocol server implementation for interacting with Anki decks programmatically. This server allows Language Models to interact with Anki through a standardized interface, with special support for Japanese language learning.
 
 ## Features
 
@@ -8,6 +8,9 @@ A Model Context Protocol server implementation for interacting with Anki decks p
 - View cards in decks
 - Add new cards
 - Review cards with spaced repetition
+- Import Japanese vocabulary with readings and meanings
+- Add sample sentences to Japanese vocabulary cards
+- Track review history and learning progress
 
 ## Installation
 
@@ -36,21 +39,40 @@ export ANKI_COLLECTION_PATH="/path/to/your/collection.anki2"
 python -m anki_mcp.server
 ```
 
-The server will start on `localhost:8000` by default.
-
 ## Available Resources
 
 - `anki://decks` - List all available Anki decks
 - `anki://deck/{deck_name}/cards` - List all cards in a specific deck
+- `anki://recent/reviewed` - View cards reviewed in the last 24 hours
+- `anki://recent/learned` - View cards learned (graduated from new) in the last 24 hours
 
 ## Available Tools
 
+### Basic Card Management
 - `add_card(deck_name: str, front: str, back: str)` - Add a new card to a deck
 - `review_card(card_id: int, ease: int)` - Review a card with a specific ease (1-4)
+- `get_card_history(card_id: int)` - Get detailed review history for a specific card
+
+### Japanese Vocabulary Features
+- `import_japanese_vocab(csv_path: str, deck_name: str, tags: str = None)` - Import Japanese vocabulary from CSV
+- `update_notes_with_sentences(vocab_sentences: Dict[str, List[str]], deck_name: str = "Try! N3 Vocab")` - Add sample sentences to vocabulary notes
+
+### Review History
+- `get_deck_review_history(deck_name: str)` - Get review history for all cards in a deck within the past 24 hours
 
 ## Available Prompts
 
 - `create_deck_prompt(deck_name: str)` - Get help creating a new deck
+- `review_history_prompt()` - Get help analyzing review history
+- `study_japanese_vocab_prompt()` - Get help with Japanese vocabulary study
+- `vocab_sentences_json_prompt()` - Generate JSON dictionary mapping vocab to sample sentences
+
+## Japanese Note Type Requirements
+
+The server expects a note type called "Japanese (recognition)" with the following fields:
+1. Expression (Japanese word)
+2. Meaning (English meaning)
+3. Reading (with furigana and sample sentences)
 
 ## License
 


### PR DESCRIPTION
This pull request introduces updates to documentation files (`README.md` and `MILESTONES.md`) to reflect new features and improvements, particularly focusing on enhanced support for Japanese language learning and review tracking in the Anki MCP Server. The changes clarify available tools, endpoints, and note type requirements.

### Documentation Updates

#### Enhanced Japanese Language Support:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R13): Added new features for importing Japanese vocabulary, adding sample sentences to vocabulary cards, and tracking learning progress. Also specified requirements for a "Japanese (recognition)" note type. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R75)

#### Review Tracking:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R75): Documented new endpoints (`anki://recent/reviewed`, `anki://recent/learned`) and tools (`get_card_history`, `get_deck_review_history`) for tracking review history and learning progress.

#### Milestone Updates:
* [`MILESTONES.md`](diffhunk://#diff-39b04a90fa3cfbca2a128e889c2518cc7b1bfc8d08535c348d4f5955826d6a90L4-R6): Marked previously listed tasks as completed, including fixing history, adapting extension tools, and matching sentences with deck entries.